### PR TITLE
Fehler behoben in binRep

### DIFF
--- a/uebung8.hs
+++ b/uebung8.hs
@@ -25,6 +25,7 @@ multList (x:xs) (y:xy) = ((x * y): multList xs xy)
 binRep :: Int -> (Int,[Int])
 binRep a
      | a < 0 = (1, getBinaryNumber ((-1)*a))
+     | a == 0 = (0, getBinaryNumber a)
      | otherwise = (0, getBinaryNumber a)
 
 getBinaryNumber :: Int -> [Int]


### PR DESCRIPTION
Habe ursprünglich die Aufgabenstellung von binRep missverstanden. Der Fehler ist hiermit behoben.